### PR TITLE
fix: path calculation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     }
   },
   "scripts": {
-    "pp": "esno packages/core/transform/transform-path.ts",
     "init": "pnpm i",
     "lint:fix": "eslint --fix ./ --ext .vue,.js,.ts,.jsx,.tsx,.json ",
     "dev": "pnpm run --filter @unplugin-vue-cssvars/build dev",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     }
   },
   "scripts": {
+    "pp": "esno packages/core/transform/transform-path.ts",
     "init": "pnpm i",
     "lint:fix": "eslint --fix ./ --ext .vue,.js,.ts,.jsx,.tsx,.json ",
     "dev": "pnpm run --filter @unplugin-vue-cssvars/build dev",

--- a/packages/core/runtime/__test__/process-css.spec.ts
+++ b/packages/core/runtime/__test__/process-css.spec.ts
@@ -9,7 +9,7 @@ describe('process css', () => {
     const mockEvt = vi.fn()
     const mockRes: Array<ICSSFile> = []
     const mockCssFiles = new Map()
-    mockCssFiles.set('foo', {
+    mockCssFiles.set('foo.css', {
       importer: new Set(),
       vBindCode: {
         foo: new Set(['v-bind(foo)']),
@@ -30,28 +30,50 @@ describe('process css', () => {
     const mockEvt = vi.fn()
     const mockRes = []
     const mockCssFiles = new Map()
-    mockCssFiles.set('foo', {
+    mockCssFiles.set('foo.css', {
       importer: new Set(['foo1', 'foo2']),
     })
-    getCSSFileRecursion('css', 'bar', mockCssFiles, (v) => {
+    const testFn = () => getCSSFileRecursion('css', 'bar', mockCssFiles, (v) => {
       mockEvt()
       mockRes.push(v)
     })
     expect(mockRes.length).toBe(0)
     expect(mockEvt).not.toBeCalled()
+    expect(testFn).toThrowError()
+  })
+
+  test('getCSSFileRecursion: not custom suffix', () => {
+    const mockEvt = vi.fn()
+    const mockRes: Array<ICSSFile> = []
+    const mockCssFiles = new Map()
+    mockCssFiles.set('foo.module.css', {
+      importer: new Set(),
+      vBindCode: {
+        foo: new Set(['v-bind(foo)']),
+      },
+    })
+    getCSSFileRecursion('css', 'foo.module', mockCssFiles, (v) => {
+      mockEvt()
+      mockRes.push(v)
+    })
+    expect(mockRes.length).toBe(1)
+    expect(mockEvt).toBeCalledTimes(1)
+    expect(mockRes[0].vBindCode).toMatchObject({
+      foo: new Set(['v-bind(foo)']),
+    })
   })
 
   test('getCSSFileRecursion: recursion', () => {
     const mockEvt = vi.fn()
     const mockRes: Array<ICSSFile> = []
     const mockCssFiles = new Map()
-    mockCssFiles.set('foo', {
-      importer: new Set(['bar']),
+    mockCssFiles.set('foo.css', {
+      importer: new Set(['bar.css']),
       vBindCode: {
         foo: new Set(['v-bind(foo)']),
       },
     })
-    mockCssFiles.set('bar', {
+    mockCssFiles.set('bar.css', {
       importer: new Set(),
       vBindCode: {
         bar: new Set(['v-bind(bar)']),
@@ -75,13 +97,13 @@ describe('process css', () => {
     const mockEvt = vi.fn()
     const mockRes: Array<ICSSFile> = []
     const mockCssFiles = new Map()
-    mockCssFiles.set('foo', {
-      importer: new Set(['bar']),
+    mockCssFiles.set('foo.css', {
+      importer: new Set(['bar.css']),
       vBindCode: {
         foo: new Set(['v-bind(foo)']),
       },
     })
-    mockCssFiles.set('bar', {
+    mockCssFiles.set('bar.css', {
       importer: new Set(['foo']),
       vBindCode: {
         bar: new Set(['v-bind(bar)']),

--- a/packages/core/runtime/__test__/process-css.spec.ts
+++ b/packages/core/runtime/__test__/process-css.spec.ts
@@ -15,7 +15,7 @@ describe('process css', () => {
         foo: new Set(['v-bind(foo)']),
       },
     })
-    getCSSFileRecursion('foo', mockCssFiles, (v) => {
+    getCSSFileRecursion('css', 'foo', mockCssFiles, (v) => {
       mockEvt()
       mockRes.push(v)
     })
@@ -33,7 +33,7 @@ describe('process css', () => {
     mockCssFiles.set('foo', {
       importer: new Set(['foo1', 'foo2']),
     })
-    getCSSFileRecursion('bar', mockCssFiles, (v) => {
+    getCSSFileRecursion('css', 'bar', mockCssFiles, (v) => {
       mockEvt()
       mockRes.push(v)
     })
@@ -57,7 +57,7 @@ describe('process css', () => {
         bar: new Set(['v-bind(bar)']),
       },
     })
-    getCSSFileRecursion('foo', mockCssFiles, (v) => {
+    getCSSFileRecursion('css', 'foo', mockCssFiles, (v) => {
       mockEvt()
       mockRes.push(v)
     })
@@ -87,7 +87,7 @@ describe('process css', () => {
         bar: new Set(['v-bind(bar)']),
       },
     })
-    getCSSFileRecursion('foo', mockCssFiles, (v) => {
+    getCSSFileRecursion('css', 'foo', mockCssFiles, (v) => {
       mockEvt()
       mockRes.push(v)
     })

--- a/packages/core/runtime/pre-process-css.ts
+++ b/packages/core/runtime/pre-process-css.ts
@@ -66,13 +66,14 @@ export function createCSSFileModuleMap(files: string[], rootDir: string) {
         fileDirParse.dir,
         value.path.replace(/^"|"$/g, ''))
       // 默认使用 .css
-      let importerVal = completeSuffix(importerPath)
+      let importerVal = completeSuffix(importerPath, SUPPORT_FILE.CSS)
       // 如果 file 不是 .css 文件，那么它的 import 需要判断处理
       if (fileSuffix !== `.${SUPPORT_FILE.CSS}`) {
-        // 先根据后缀名查找是否存在该文件
+        // 根据后缀名查找是否存在该文件
         const importerValBySuffix = completeSuffix(
           importerPath,
           fileSuffix.split('.')[1],
+          true,
         )
         // 存在就使用 fileSuffix 的后缀文件
         if (cssFiles.get(importerValBySuffix))

--- a/packages/core/runtime/process-css.ts
+++ b/packages/core/runtime/process-css.ts
@@ -5,22 +5,21 @@ import type { ICSSFile, ICSSFileMap } from '../types'
 import type { SFCDescriptor } from '@vue/compiler-sfc'
 
 export const getCSSFileRecursion = (
-  lang: string | undefined,
+  lang: string = SUPPORT_FILE.CSS,
   key: string,
   cssFiles: ICSSFileMap,
   cb: (res: ICSSFile) => void,
   matchedMark = new Set<string>()) => {
-  // 避免循环引用
-  if (matchedMark.has(key)) return
   // 添加后缀
   // sfc中规则：如果@import 指定了后缀，则根据后缀，否则根据当前 script 标签的 lang 属性（默认css）
   key = completeSuffix(key, lang)
   // 如果 .scss 的 import 不存在，则用 css 的
   if (!cssFiles.get(key))
-    key = completeSuffix(key)
+    key = completeSuffix(key, SUPPORT_FILE.CSS, true)
 
+  // 避免循环引用
+  if (matchedMark.has(key)) return
   const cssFile = cssFiles.get(key)
-  console.log(key)
   if (cssFile) {
     matchedMark.add(key)
     cb(cssFile)
@@ -30,7 +29,7 @@ export const getCSSFileRecursion = (
       })
     }
   } else {
-    throw new Error(`The writing of the path '${key}' is not standardized, which may cause \`v-bind-m\` to fail to take effect`)
+    throw new Error(`The writing of the path '${key}' is not standardized or undefined, which may cause \`v-bind-m\` to fail to take effect`)
   }
 }
 

--- a/packages/core/runtime/process-css.ts
+++ b/packages/core/runtime/process-css.ts
@@ -29,7 +29,7 @@ export const getCSSFileRecursion = (
       })
     }
   } else {
-    throw new Error(`The writing of the path '${key}' is not standardized or undefined, which may cause \`v-bind-m\` to fail to take effect`)
+    throw new Error('path')
   }
 }
 
@@ -59,15 +59,24 @@ export const getVBindVariableListByPath = (
     parseImporterRes.imports.forEach((res) => {
       const importerPath = resolve(idDirParse.dir, res.path)
 
-      // 根据 @import 信息，从 cssFiles 中，递归的获取所有在预处理时生成的 cssvars 样式
-      getCSSFileRecursion(lang, importerPath, cssFiles, (res: ICSSFile) => {
-        if (res.vBindCode) {
-          !server && injectCSSContent.add({ content: res.content, lang: res.lang, styleTagIndex: i })
-          res.vBindCode.forEach((vb) => {
-            vbindVariable.add(vb)
-          })
+      try {
+        // 根据 @import 信息，从 cssFiles 中，递归的获取所有在预处理时生成的 cssvars 样式
+        getCSSFileRecursion(lang, importerPath, cssFiles, (res: ICSSFile) => {
+          if (res.vBindCode) {
+            !server && injectCSSContent.add({ content: res.content, lang: res.lang, styleTagIndex: i })
+            res.vBindCode.forEach((vb) => {
+              vbindVariable.add(vb)
+            })
+          }
+        })
+      } catch (e) {
+        if ((e as Error).message === 'path') {
+          const doc = 'https://github.com/baiwusanyu-c/unplugin-vue-cssvars/pull/29'
+          throw new Error(`Unable to resolve file under path '${res.path}', see: ${doc}`)
+        } else {
+          throw new Error((e as Error).message)
         }
-      })
+      }
     })
   }
   return {

--- a/play/src/main.ts
+++ b/play/src/main.ts
@@ -1,3 +1,3 @@
 import { createApp } from 'vue'
-import App from './App.vue'
+import App from './views/app/App.vue'
 createApp(App).mount('#app')

--- a/play/src/views/app/App.vue
+++ b/play/src/views/app/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { reactive, ref } from 'vue'
-import Comp from './comp.vue'
+import Comp from '../../comp.vue'
 const color = 'green'
 const appAsd = () => 'red'
 const fooColor = appAsd()
@@ -79,8 +79,8 @@ export default defineComponent({
 </template>
 
 <style lang="scss" scoped>
-@import './assets/scss/mixin.scss';
-@import './assets/scss/variables.module.scss';
+@import './src/assets/scss/mixin';
+@import '../../assets/scss/variables.module';
 /* foo.scss -> test2.css -> test.css */
 /* foo.scss -> test.scss -> test2.css */
 

--- a/play/src/views/app/App.vue
+++ b/play/src/views/app/App.vue
@@ -79,7 +79,7 @@ export default defineComponent({
 </template>
 
 <style lang="scss" scoped>
-@import './src/assets/scss/mixin';
+@import '../src/assets/scss/mixin';
 @import '../../assets/scss/variables.module';
 /* foo.scss -> test2.css -> test.css */
 /* foo.scss -> test.scss -> test2.css */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
       '@vitest/ui': ^0.29.2
       '@vue/compiler-sfc': ^3.2.47
       bumpp: ^8.2.1
-      chalk: ^5.2.0
+      chalk: ^4.1.2
       conventional-changelog-cli: ^2.2.2
       cross-env: ^7.0.3
       debug: ^4.3.4
@@ -50,7 +50,7 @@ importers:
       vitest: ^0.29.2
       vue: ^3.2.47
     dependencies:
-      chalk: 5.2.0
+      chalk: 4.1.2
       estree-walker: 3.0.3
       fast-glob: 3.2.12
       fs-extra: 10.1.0
@@ -1875,11 +1875,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  /chalk/5.2.0:
-    resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: false
 
   /character-entities-legacy/1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}

--- a/utils/constant.ts
+++ b/utils/constant.ts
@@ -1,5 +1,6 @@
 export const NAME = 'unplugin-vue-cssvars'
 export const SUPPORT_FILE_LIST = ['**/**.css']
+export const SUPPORT_FILE_REG = /\.(css|sass|scss|styl|less)$/i
 export const FG_IGNORE_LIST = ['**/node_modules/**', '**/dist/**', '**/.git/**']
 export const SUPPORT_FILE = {
   CSS: 'css',

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,4 +1,4 @@
-import { SUPPORT_FILE } from './constant'
+import { SUPPORT_FILE, SUPPORT_FILE_REG } from './constant'
 
 export * from './constant'
 
@@ -18,5 +18,5 @@ export const transformSymbol = (path: string) => path.replaceAll('\\', '/')
 
 export const completeSuffix = (fileName: string, suffix = SUPPORT_FILE.CSS) => {
   const transformSymbolRes = transformSymbol(fileName)
-  return !(/\.[^./\\]+$/i.test(transformSymbolRes)) ? `${transformSymbolRes}.${suffix}` : transformSymbolRes
+  return !(SUPPORT_FILE_REG.test(transformSymbolRes)) ? `${transformSymbolRes}.${suffix}` : transformSymbolRes
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,5 +1,5 @@
+import { join, parse } from 'path'
 import { SUPPORT_FILE, SUPPORT_FILE_REG } from './constant'
-
 export * from './constant'
 
 export const extend = <
@@ -16,7 +16,11 @@ export const isEmptyObj = (val: unknown) => JSON.stringify(val) === '{}'
 
 export const transformSymbol = (path: string) => path.replaceAll('\\', '/')
 
-export const completeSuffix = (fileName: string, suffix = SUPPORT_FILE.CSS) => {
+export const completeSuffix = (fileName: string, suffix: string, force?: boolean) => {
   const transformSymbolRes = transformSymbol(fileName)
-  return !(SUPPORT_FILE_REG.test(transformSymbolRes)) ? `${transformSymbolRes}.${suffix}` : transformSymbolRes
+  if (force) {
+    const { dir, name } = parse(transformSymbolRes)
+    return transformSymbol(join(dir, `${name}.${suffix || SUPPORT_FILE.CSS}`))
+  }
+  return !(SUPPORT_FILE_REG.test(transformSymbolRes)) && suffix ? `${transformSymbolRes}.${suffix}` : transformSymbolRes
 }


### PR DESCRIPTION
For example: `./src/assets/scss/mixin`
He is a relative path, `./ ` points to the current directory, and different IDE(maybe vite ?) seem to do it differently

![image](https://user-images.githubusercontent.com/32354856/229452258-51ad7258-d49c-460c-8eee-0a578d78d9e8.png)
![6853d02aea69ccae470f5b1b0da1a8b](https://user-images.githubusercontent.com/32354856/229452803-22133bee-c557-4e9d-8887-f9213f0e318d.jpg)

`unplugin-vue-cssvars`  use  `resolve` to handle the path, so you should modify the code like `../../assets/scss/mixin`